### PR TITLE
fix explicit new

### DIFF
--- a/src/lua_cb_gfx.cpp
+++ b/src/lua_cb_gfx.cpp
@@ -29,8 +29,8 @@ struct imgHandle_s {
 int l_NewImageHandle(lua_State* L)
 {
     // Creates an image handle referencing LazyLoadedTexture 0
-    auto imgHandle = (imgHandle_s*)lua_newuserdata(L, sizeof(imgHandle_s));
-    new (imgHandle) imgHandle_s;
+    auto imgHandle = static_cast<imgHandle_s*>(lua_newuserdata(L, sizeof(imgHandle_s)));
+    std::ranges::construct_at(imgHandle);
     lua_pushvalue(L, lua_upvalueindex(1));
     lua_setmetatable(L, -2);
     return 1;
@@ -366,7 +366,7 @@ DrawStringCmd::DrawStringCmd(float X, float Y, int Align, int Size, int Font, co
 
     QString cacheKey = (QString::number(Font) + "_" + QString::number(Size) + "_" + text);
     if (pobwindow->stringCache.contains(cacheKey)) {
-        tex = *pobwindow->stringCache[cacheKey];
+        tex = pobwindow->stringCache[cacheKey];
     } else {
         QString fontName;
         switch (Font) {
@@ -398,11 +398,11 @@ DrawStringCmd::DrawStringCmd(float X, float Y, int Align, int Size, int Font, co
             p.end();
             tex.reset(new QOpenGLTexture(brush));
         }
-        pobwindow->stringCache.insert(cacheKey, new std::shared_ptr<QOpenGLTexture>(tex));
+        pobwindow->stringCache.emplace(cacheKey, tex);
     }
     int width = 0;
     int height = 0;
-    if (tex.get() != nullptr) {
+    if (tex) {
         width = tex->width();
         height = tex->height();
     }
@@ -494,8 +494,8 @@ int l_DrawStringWidth(lua_State* L)
     text.remove(colourCodes);
 
     QString cacheKey = (fontKey + "_" + QString::number(fontsize) + "_" + text);
-    if (pobwindow->stringCache.contains(cacheKey) && pobwindow->stringCache[cacheKey]->get()) {
-        lua_pushinteger(L, (*pobwindow->stringCache[cacheKey])->width());
+    if (pobwindow->stringCache.contains(cacheKey) && pobwindow->stringCache[cacheKey]) {
+        lua_pushinteger(L, pobwindow->stringCache[cacheKey]->width());
         return 1;
     }
 

--- a/src/pobwindow.cpp
+++ b/src/pobwindow.cpp
@@ -149,9 +149,6 @@ void POBWindow::paintGL() {
         lua_error(L);
     }
 
-    if (dscount > stringCache.maxCost()) {
-        stringCache.setMaxCost(static_cast<int>(1.2f * dscount));
-    }
     if (uniqueTextureDrawn.size() > textureCache.maxCost()) {
         textureCache.setMaxCost(static_cast<int>(1.2f * uniqueTextureDrawn.size()));
     }

--- a/src/pobwindow.hpp
+++ b/src/pobwindow.hpp
@@ -8,6 +8,7 @@
 #include <QSet>
 #include <QStandardPaths>
 #include <QTimer>
+#include <unordered_map>
 
 #include "main.h"
 #include "qevent.h"
@@ -18,7 +19,7 @@
 class POBWindow : public QOpenGLWindow {
     Q_OBJECT
 public:
-    POBWindow() : stringCache(200), textureCache(12) {
+    POBWindow() : stringCache(), textureCache(12) {
         QString AppDataLocation = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
         scriptPath = QDir::currentPath() + "/src";
         scriptWorkDir = QDir::currentPath() + "/src";
@@ -97,7 +98,7 @@ public:
     QHash<QString, TextureIndex> textureIndexByPath;
     QSet<size_t> uniqueTextureDrawn;
     QList<LazyLoadedTexture> lazyLoadedTexture;
-    QCache<QString, std::shared_ptr<QOpenGLTexture>> stringCache;
+    std::unordered_map<QString, std::shared_ptr<QOpenGLTexture>> stringCache;
     QCache<size_t, QOpenGLTexture> textureCache;
     QTimer repaintTimer;
 };


### PR DESCRIPTION
replace explicit `new` to STL-entities.
replace `QCache` to `std::unordered_map` -- `QCash` applies a cost to the `shared-ptr`s themselves (not data) and `new std::shared_ptr<Type>(v)` is _pointer-to-pointer_ in QCache